### PR TITLE
Added 12 unique plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,27 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
  - [babel-watch](https://github.com/kmagiera/babel-watch) - Reloads a node app on file changes
 
+## Optimization
+
+ - [groundskeeper-willie](https://github.com/betaorbust/babel-plugin-groundskeeper-willie) - Removes debugger and console calls
+ - [loop-optimizer](https://github.com/vihanb/babel-plugin-loop-optimizer) - Transforms `.forEach` and `.map` calls to for loops
+ - [closure-elimination](https://github.com/codemix/babel-plugin-closure-elimination) - Transforms closures into separate functions
+
+## Syntax Sugar
+
+ - [implicit-return](https://github.com/miraks/babel-plugin-implicit-return) - Transforms last statement in a function block to a return statement
+ - [transform-iota](https://github.com/passcod/babel-plugin-transform-iota) - Golang-style `iota()`
+ - [offside-js](https://github.com/shanewholloway/babel-plugin-offside-js) - Coffeescript-like indented block syntax hack (work in progress)
+ - [trace](https://github.com/codemix/babel-plugin-trace) - Syntax shortcuts for console logging
+ - [meaningful-logs](https://github.com/furstenheim/babel-plugin-meaningful-logs) - Adds file name and line number of caller to `console.log()` calls
+
+## Alternative Programming Paradigms
+
+ - [macros](https://github.com/codemix/babel-plugin-macros) - Hygienic, non-syntactic macros
+ - [contracts](https://github.com/codemix/babel-plugin-contracts) - Design by Contract; Includes preconditions, postconditions, and invariant conditions
+ - [transform-scala-lambda](https://github.com/xtuc/babel-plugin-transform-scala-lambda) - Enable Scala-style lambdas
+ - [overload](https://github.com/foxbenjaminfox/babel-plugin-overload) - Allow overloading default operators like `+` or `===` for specific classes
+
 ## License
 
 [![CC0](https://i.creativecommons.org/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
One night, I was trying to find a Babel plugin that enables CoffeeScript-like block indentation syntax. I found offside-js, which I also included. I also found a few more unique and interesting (to me) plugins that were not in this list:

## Optimization

 - [groundskeeper-willie](https://github.com/betaorbust/babel-plugin-groundskeeper-willie) - Removes debugger and console calls
 - [loop-optimizer](https://github.com/vihanb/babel-plugin-loop-optimizer) - Transforms `.forEach` and `.map` calls to for loops
 - [closure-elimination](https://github.com/codemix/babel-plugin-closure-elimination) - Transforms closures into separate functions

## Syntax Sugar

 - [implicit-return](https://github.com/miraks/babel-plugin-implicit-return) - Transforms last statement in a function block to a return statement
 - [transform-iota](https://github.com/passcod/babel-plugin-transform-iota) - Golang-style `iota()`
 - [offside-js](https://github.com/shanewholloway/babel-plugin-offside-js) - Coffeescript-like indented block syntax hack (work in progress)
 - [trace](https://github.com/codemix/babel-plugin-trace) - Syntax shortcuts for console logging
 - [meaningful-logs](https://github.com/furstenheim/babel-plugin-meaningful-logs) - Adds file name and line number of caller to `console.log()` calls

## Alternative Programming Paradigms

 - [macros](https://github.com/codemix/babel-plugin-macros) - Hygienic, non-syntactic macros
 - [contracts](https://github.com/codemix/babel-plugin-contracts) - Design by Contract; Includes preconditions, postconditions, and invariant conditions
 - [transform-scala-lambda](https://github.com/xtuc/babel-plugin-transform-scala-lambda) - Enable Scala-style lambdas
 - [overload](https://github.com/foxbenjaminfox/babel-plugin-overload) - Allow overloading default operators like `+` or `===` for specific classes