### PR TITLE
Add jsdoc-to-assert

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
 
  - [flow-runtime](https://github.com/codemix/flow-runtime/tree/master/packages/babel-plugin-flow-runtime) - Turns Flow annotations into runtime checks. Part of [Flow-Runtime](https://codemix.github.io/flow-runtime).
  - [tcomb](https://github.com/gcanti/babel-plugin-tcomb) - Turns Flow annotations into typechecks with [tcomb](https://github.com/gcanti/tcomb).
+ - [jsdoc-to-assert](https://github.com/azu/babel-plugin-jsdoc-to-assert) - Turns JSDoc into runtime checks.
 
 ### Testing
 


### PR DESCRIPTION
Add https://github.com/azu/babel-plugin-jsdoc-to-assert to `Types`.