### PR TITLE
Add `transform-named-import`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,8 @@ If you want to contribute, please read the [contribution guidelines](contributin
  - [groundskeeper-willie](https://github.com/betaorbust/babel-plugin-groundskeeper-willie) - Removes debugger and console calls.
  - [loop-optimizer](https://github.com/vihanb/babel-plugin-loop-optimizer) - Transforms `.forEach` and `.map` calls to for loops. 🔧
  - [closure-elimination](https://github.com/codemix/babel-plugin-closure-elimination) - Transforms closures into separate functions.
- - [preval](https://github.com/kentcdodds/babel-plugin-preval) - Pre-evaluate code at build-time
+ - [preval](https://github.com/kentcdodds/babel-plugin-preval) - Pre-evaluate code at build-time.
+ - [transform-named-imports](https://github.com/SectorLabs/babel-plugin-transform-named-imports) - Avoid including code that you don't need from modules you're importing.
 
 ### Syntax Sugar
 


### PR DESCRIPTION
`babel-plugin-transform-named-import` transforms your named imports into absolute default imports to avoid importing everything else in the `index.js` file. This makes tree shaking a lot more effective and decreases your bundle size.