### PR TITLE
Add babel-plugin-test-ids plugin information

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ If you want to contribute, please read the [contribution guidelines](contributin
  - [espower](https://github.com/power-assert-js/babel-plugin-espower) - Annotates call sites for descriptive messages when using [power-assert](https://github.com/power-assert-js/power-assert).
  - [istanbul](https://github.com/istanbuljs/babel-plugin-istanbul) - Instruments your code with Istanbul coverage.
  - [rewire](https://github.com/speedskater/babel-plugin-rewire) - Adds the ability to rewire module dependencies. This enables to mock modules for testing purposes.
+ - [test-ids](https://github.com/alsiola/test-ids) - Create and extract test ids with no runtime cost.
 
 ### Optimization
 


### PR DESCRIPTION
See https://github.com/alsiola/test-ids

This plugin allows definition of test ids across an application - they are then transformed to string literals to minimise runtime cost, and extracted for distribution to e.g. QA